### PR TITLE
Include Code in the Registration Request

### DIFF
--- a/app/Services/User/UserService.php
+++ b/app/Services/User/UserService.php
@@ -186,8 +186,8 @@ class UserService extends BaseService implements IUserService
                 DB::commit();
 
 
-                $response_message = $this->customHttpResponse(200, 'Registration successful.');
-                return $response_message;
+                $data = isset($this->payload['_with_code']) ? ['verification_code' => $code] : [];
+                return $this->customHttpResponse(200, 'Registration successful.', $data);
             } catch (\Throwable $th) {
 
                 DB::rollBack();


### PR DESCRIPTION
When an hidden `_with_code` request parameter is passed within the payload, the endpoint should return the code.

This is mainly so that the calling service can call `email_verify_code` by itself.